### PR TITLE
Improve pickling

### DIFF
--- a/serial-core/src/main/scala/io/github/finagle/serial/package.scala
+++ b/serial-core/src/main/scala/io/github/finagle/serial/package.scala
@@ -38,8 +38,6 @@ package object serial {
     } yield out
   }
 
-  // Errors produced by codec
-  abstract sealed class ClientError(message: String) extends Exception(message)
-  case class SerializationFailed(reason: String) extends ClientError(reason)
-  case class DeserializationFailed(reason: String) extends ClientError(reason)
+  // Errors produced by client-side codec
+  case class ClientError(message: String) extends Exception(message)
 }

--- a/serial-core/src/main/scala/io/github/finagle/serial/package.scala
+++ b/serial-core/src/main/scala/io/github/finagle/serial/package.scala
@@ -39,7 +39,7 @@ package object serial {
   }
 
   // Errors produced by codec
-  abstract sealed class CodecError(message: String) extends Exception(message)
-  case class SerializationFailed(reason: String) extends CodecError(reason)
-  case class DeserializationFailed(reason: String) extends CodecError(reason)
+  abstract sealed class ClientError(message: String) extends Exception(message)
+  case class SerializationFailed(reason: String) extends ClientError(reason)
+  case class DeserializationFailed(reason: String) extends ClientError(reason)
 }

--- a/serial-pickling/src/main/scala/io/github/finagle/serial/pickling/package.scala
+++ b/serial-pickling/src/main/scala/io/github/finagle/serial/pickling/package.scala
@@ -10,13 +10,13 @@ package object pickling {
     override val serialize = new Serialize[A] {
       override def apply(o: A): Try[Array[Byte]] =
         try { Return(o.pickle.value) }
-        catch { case e: Exception => Throw(SerializationFailed(e.getMessage)) }
+        catch { case e: Exception => Throw(ClientError(e.getMessage)) }
     }
 
     override val deserialize = new Deserialize[A] {
       override def apply(a: Array[Byte]): Try[A] =
         try { Return(a.unpickle[A]) }
-        catch { case e: Exception => Throw(DeserializationFailed(e.getMessage)) }
+        catch { case e: Exception => Throw(ClientError(e.getMessage)) }
     }
   }
 }

--- a/serial-pickling/src/main/scala/io/github/finagle/serial/pickling/package.scala
+++ b/serial-pickling/src/main/scala/io/github/finagle/serial/pickling/package.scala
@@ -10,13 +10,13 @@ package object pickling {
     override val serialize = new Serialize[A] {
       override def apply(o: A): Try[Array[Byte]] =
         try { Return(o.pickle.value) }
-        catch { case e: Exception => Throw(e) }
+        catch { case e: Exception => Throw(SerializationFailed(e.getMessage)) }
     }
 
     override val deserialize = new Deserialize[A] {
       override def apply(a: Array[Byte]): Try[A] =
         try { Return(a.unpickle[A]) }
-        catch { case e: Exception => Throw(e) }
+        catch { case e: Exception => Throw(DeserializationFailed(e.getMessage)) }
     }
   }
 }

--- a/serial-pickling/src/test/scala/io/github/finagle/serial/pickling/PicklingCodecSpec.scala
+++ b/serial-pickling/src/test/scala/io/github/finagle/serial/pickling/PicklingCodecSpec.scala
@@ -5,7 +5,6 @@ import java.net.InetSocketAddress
 import com.twitter.finagle.Service
 import com.twitter.util.{Future, Await, Return}
 import io.github.finagle.Serial
-import io.github.finagle.serial.Codec
 import org.scalatest.{Matchers, FlatSpec}
 
 class PicklingCodecSpec extends FlatSpec with Matchers {

--- a/serial-scodec/src/main/scala/io/github/finagle/serial/scodec/package.scala
+++ b/serial-scodec/src/main/scala/io/github/finagle/serial/scodec/package.scala
@@ -9,14 +9,14 @@ package object scodec {
   implicit def toSerialCodec[A](implicit scodec: Scodec[A]): Codec[A] = new Codec[A] {
     override val serialize = new Serialize[A] {
       override def apply(o: A): Try[Array[Byte]] = scodec.encode(o).fold(
-        e => Throw(SerializationFailed(e.message)),
+        e => Throw(ClientError(e.message)),
         bits => Return(bits.toByteArray)
       )
     }
 
     override val deserialize = new Deserialize[A] {
       override def apply(a: Array[Byte]): Try[A] = scodec.decodeValue(BitVector(a)).fold(
-        e => Throw(DeserializationFailed(e.message)),
+        e => Throw(ClientError(e.message)),
         o => Return(o)
       )
     }


### PR DESCRIPTION
- Use proper exception types in pickling
- Rename `CodecError`/`SerializationFailed`/`DeserializationFailed` -> `ClientError`
- Add Readme section on error hadnlign

I merged all the exception types we had into `ClientError`. Looks strange at the first glance, but this allowed to handle error in a nice and readable way:

``` scala
future.handle {
  case ClientError(wat) => transport error at the client side
  case ServerError(wat) => transport error at the server side
  case ServerApplicationError(wat) => user code error
}  
```
