### PR TITLE
Add serial-benchmark

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val root = project.in(file("."))
   .settings(moduleName := "finagle-serial")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
-  .aggregate(core, pickling, scodec)
+  .aggregate(core, pickling, scodec, benchmark)
 
 lazy val core = project.in(file("serial-core"))
   .settings(moduleName := "finagle-serial-core")
@@ -35,6 +35,13 @@ lazy val scodec = project.in(file("serial-scodec"))
   .settings(publishSettings: _*)
   .settings(libraryDependencies += "org.typelevel" %% "scodec-core" % "1.6.0")
   .dependsOn(core)
+
+lazy val benchmark = project.in(file("serial-benchmark"))
+  .settings(moduleName := "finagle-serial-bencrhmark")
+  .settings(commonSettings: _*)
+  .settings(publishSettings: _*)
+  .settings(jmhSettings: _*)
+  .dependsOn(core, pickling, scodec)
 
 lazy val publishSettings = Seq(
   publishMavenStyle := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,5 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.7")

--- a/serial-benchmark/src/main/scala/i.g.f.s/Medium.scala
+++ b/serial-benchmark/src/main/scala/i.g.f.s/Medium.scala
@@ -1,0 +1,17 @@
+package i.g.f.s
+
+case class Medium(map: Map[String, String], l: Long, seq: Seq[Small])
+
+object Medium {
+  val ten = Medium(
+    (for(i <- 1 to 10) yield (i.toString, i.toString)).toMap,
+    100l,
+    for (i <- 1 to 10) yield Small.ten
+  )
+
+  val hundred = Medium(
+    (for(i <- 1 to 100) yield (i.toString, i.toString)).toMap,
+    200l,
+    for (i <- 1 to 100) yield Small.hundred
+  )
+}

--- a/serial-benchmark/src/main/scala/i.g.f.s/SerialBenchmark.scala
+++ b/serial-benchmark/src/main/scala/i.g.f.s/SerialBenchmark.scala
@@ -1,0 +1,10 @@
+package i.g.f.s
+
+import com.twitter.finagle.Service
+import com.twitter.util.Future
+
+trait SerialBenchmark[A] {
+  val echo = new Service[A, A] {
+    override def apply(req: A) = Future.value(req)
+  }
+}

--- a/serial-benchmark/src/main/scala/i.g.f.s/Small.scala
+++ b/serial-benchmark/src/main/scala/i.g.f.s/Small.scala
@@ -1,0 +1,8 @@
+package i.g.f.s
+
+case class Small(list: List[Int], s: String)
+
+object Small {
+  val ten = Small((1 to 10).toList, "small10")
+  val hundred = Small((1 to 100).toList, "small100")
+}

--- a/serial-benchmark/src/main/scala/i.g.f.s/SmallPicklingBenchmark.scala
+++ b/serial-benchmark/src/main/scala/i.g.f.s/SmallPicklingBenchmark.scala
@@ -1,0 +1,44 @@
+package i.g.f.s
+
+import java.net.InetSocketAddress
+import java.util.concurrent.TimeUnit
+
+import com.twitter.finagle.{Service, ListeningServer}
+import com.twitter.util.Await
+
+import io.github.finagle.Serial
+import io.github.finagle.serial.pickling._
+
+import org.openjdk.jmh.annotations._
+
+/**
+ * 'run -i 10 -wi 7 -f 2 -t 1 i.g.f.s.PicklingBenchmark'
+ */
+@State(Scope.Thread)
+class SmallPicklingBenchmark extends SerialBenchmark[Small] {
+
+  var server: ListeningServer = _
+  var client: Service[Small, Small] = _
+
+  @Setup
+  def setUp(): Unit = {
+    server = Serial[Small, Small].serve(new InetSocketAddress(8123), echo)
+    client = Serial[Small, Small].newService("localhost:8123")
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    Await.ready(client.close())
+    Await.ready(server.close())
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def testSmall10 = Await.result(client(Small.ten))
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def testSmall100 = Await.result(client(Small.hundred))
+}


### PR DESCRIPTION
Use JMH to benchmark Finagle Serial. This is a sketch, but it works. I'm going to continue working on it. The current results on a small data for pickling:

```
[info] Benchmark                                       Mode  Samples   Score   Error  Units
[info] i.g.f.s.SmallPicklingBenchmark.testSmall10     thrpt       20  37.377 ± 3.990  ops/s
[info] i.g.f.s.SmallPicklingBenchmark.testSmall100    thrpt       20   3.579 ± 0.499  ops/s
```
