### PR TITLE
Integration tests with Scalacheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+
+script: "sbt ++$TRAVIS_SCALA_VERSION test it:test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: scala
 
 scala:
   - 2.10.4
-  - 2.11.4
+  - 2.11.5
 
 jdk:
   - openjdk7

--- a/build.sbt
+++ b/build.sbt
@@ -20,12 +20,19 @@ lazy val root = project.in(file("."))
   .settings(moduleName := "finagle-serial")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
-  .aggregate(core, scodec, benchmark)
+  .aggregate(core, test, scodec, benchmark)
 
 lazy val core = project
   .settings(moduleName := "finagle-serial-core")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
+
+lazy val test = project
+  .settings(moduleName := "finagle-serial-test")
+  .settings(commonSettings: _*)
+  .settings(publishSettings: _*)
+  .settings(libraryDependencies ++= testDependencies)
+  .dependsOn(core)
 
 lazy val scodecSettings = Seq(
   resolvers += Resolver.sonatypeRepo("snapshots"),
@@ -34,10 +41,12 @@ lazy val scodecSettings = Seq(
 
 lazy val scodec = project
   .settings(moduleName := "finagle-serial-scodec")
+  .configs(IntegrationTest)
+  .settings(Defaults.itSettings: _*)
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(scodecSettings: _*)
-  .dependsOn(core)
+  .dependsOn(core, test % "it")
 
 lazy val benchmark = project
   .settings(moduleName := "finagle-serial-benchmark")

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,19 @@
 lazy val commonSettings = Seq(
   organization := "io.github.finagle",
   version := "0.0.1",
-  scalaVersion := "2.11.4",
-  crossScalaVersions := Seq("2.10.4", "2.11.4"),
+  scalaVersion := "2.11.5",
+  crossScalaVersions := Seq("2.10.4", "2.11.5"),
   libraryDependencies ++= Seq(
-    "com.twitter" %% "finagle-mux" % "6.24.0",
-    "org.scalatest" %% "scalatest" % "2.2.1" % "test"
-  ),
+    "com.twitter" %% "finagle-mux" % "6.24.0"
+  ) ++ testDependencies.map(_ % "test"),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
   resolvers += "Twitter's Repository" at "http://maven.twttr.com/",
   parallelExecution in Test := false
+)
+
+lazy val testDependencies = Seq(
+  "org.scalatest" %% "scalatest" % "2.2.3",
+  "org.scalacheck" %% "scalacheck" % "1.12.1"
 )
 
 lazy val root = project.in(file("."))
@@ -18,7 +22,7 @@ lazy val root = project.in(file("."))
   .settings(publishSettings: _*)
   .aggregate(core, scodec, benchmark)
 
-lazy val core = project.in(file("core"))
+lazy val core = project
   .settings(moduleName := "finagle-serial-core")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
@@ -28,18 +32,14 @@ lazy val scodecSettings = Seq(
   libraryDependencies += "org.typelevel" %% "scodec-core" % "1.7.0-SNAPSHOT"
 )
 
-lazy val scodec = project.in(file("scodec"))
+lazy val scodec = project
   .settings(moduleName := "finagle-serial-scodec")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(scodecSettings: _*)
-  .settings(
-    resolvers += Resolver.sonatypeRepo("snapshots"),
-    libraryDependencies += "org.typelevel" %% "scodec-core" % "1.7.0-SNAPSHOT"
-  )
   .dependsOn(core)
 
-lazy val benchmark = project.in(file("benchmark"))
+lazy val benchmark = project
   .settings(moduleName := "finagle-serial-benchmark")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ resolvers ++= Seq(
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.8")

--- a/scodec/src/it/scala/io/github/finagle/serial/scodec/ScodecIntegrationTest.scala
+++ b/scodec/src/it/scala/io/github/finagle/serial/scodec/ScodecIntegrationTest.scala
@@ -1,0 +1,37 @@
+package io.github.finagle.serial.scodec
+
+import _root_.scodec._
+import _root_.scodec.codecs._
+import io.github.finagle.serial.test.SerialIntegrationTest
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.FunSuite
+
+class ScodecIntegrationTest extends FunSuite with ScodecSerial with SerialIntegrationTest {
+  implicit val intCodec: Codec[Int] = int32
+  implicit val stringCodec: Codec[String] = variableSizeBits(uint24, utf8)
+
+  case class Foo(i: Int, s: String)
+
+  implicit val fooCodec: Codec[Foo] = (uint8 :: stringCodec).as[Foo]
+
+  implicit val fooArbitrary: Arbitrary[Foo] = Arbitrary(
+    for {
+      i <- Gen.choose(0, 255)
+      s <- Gen.alphaStr
+    } yield Foo(i, s)
+  )
+
+  test("A service that doubles an integer should work on all integers") {
+    testFunctionService[Int, Int](_ * 2)
+  }
+
+  test("A service that returns the length of a string should work on all strings") {
+    testFunctionService[String, Int](s => s.length)
+  }
+
+  test("A service that changes a case class should work on all instances") {
+    testFunctionService[Foo, Foo] {
+      case Foo(i, s) => Foo(i % 128, s * 2)
+    }
+  }
+}

--- a/scodec/src/main/scala/io/github/finagle/serial/scodec/ScodecSerial.scala
+++ b/scodec/src/main/scala/io/github/finagle/serial/scodec/ScodecSerial.scala
@@ -8,7 +8,6 @@ import io.github.finagle.Serial
 import io.github.finagle.serial.{EncodingError, UnencodedError}
 
 trait ScodecSerial extends Serial {
-
   type C[A] = Codec[A]
 
   private[this] val stringWithLength: Codec[String] = variableSizeBits(uint24, utf8)

--- a/scodec/src/test/scala/io/github/finagle/serial/scodec/ScodecCodecSpec.scala
+++ b/scodec/src/test/scala/io/github/finagle/serial/scodec/ScodecCodecSpec.scala
@@ -8,7 +8,6 @@ import java.net.InetSocketAddress
 import org.scalatest.{Matchers, FlatSpec}
 
 class ScodecCodecSpec extends FlatSpec with Matchers {
-
   case class Point(x: Double, y: Double)
 
   "An Scodec Codec" should "work being used standalone" in {

--- a/test/src/main/scala/io/github/finagle/serial/test/SerialIntegrationTest.scala
+++ b/test/src/main/scala/io/github/finagle/serial/test/SerialIntegrationTest.scala
@@ -1,0 +1,69 @@
+package io.github.finagle.serial.test
+
+import com.twitter.finagle.{Client, ListeningServer, Server, Service}
+import com.twitter.util.{Await, Future, Try}
+import io.github.finagle.Serial
+import java.net.{InetAddress, InetSocketAddress}
+import org.scalatest.Matchers
+import org.scalatest.prop.Checkers
+import org.scalacheck.{Arbitrary, Gen, Prop}
+
+/**
+ * Convenience trait for creating integration tests for Serial implementations.
+ */
+trait SerialIntegrationTest extends Checkers with Matchers { this: Serial =>
+
+  /**
+   * A property that confirms that a service returns the same values (and fails
+   * with the same errors) as a given function.
+   */
+  def serviceFunctionProp[I, O](client: Service[I, O])(f: I => O)(gen: Gen[I]): Prop =
+    Prop.forAll(gen) { in =>
+      Await.result(client(in).liftToTry.map(_ === Try(f(in))))
+    }
+
+  /**
+   * Create a server and client pair for a service that wraps a given function.
+   *
+   * The server and client will use an ephemeral port. Note that it is the
+   * caller's responsibility to close the server.
+   */
+  def createServerAndClient[I, O](
+    f: I => O
+  )(implicit
+    inCodec: C[I],
+    outCodec: C[O]
+  ): (ListeningServer, Service[I, O]) = {
+    val address = new InetSocketAddress(InetAddress.getLoopbackAddress, 0)
+    val service = new Service[I, O] {
+      def apply(i: I): Future[O] = Future.value(f(i))
+    }
+
+    val serial = apply[I, O](inCodec, outCodec)
+
+    val fServer = serial.serve(address, service)
+    val port = fServer.boundAddress.asInstanceOf[InetSocketAddress].getPort
+
+    val fClient = Await.result(serial.newClient(s"localhost:$port")())
+
+    (fServer, fClient)
+  }
+
+  /**
+   * Create a server for a service that wraps a given function and confirm that
+   * calling it from a client returns the same results.
+   */
+  def testFunctionService[I, O](
+    f: I => O
+  )(implicit
+    inCodec: C[I],
+    outCodec: C[O],
+    arb: Arbitrary[I]
+  ): Unit = {
+    val (fServer, fClient) = createServerAndClient(f)(inCodec, outCodec)
+
+    check(serviceFunctionProp(fClient)(f)(arb.arbitrary))
+
+    Await.result(fServer.close())
+  }
+}


### PR DESCRIPTION
Hey @vkostyukov, I'm still not really happy with the exception encoding business for Scodec, but I'm hoping to have something up tonight. In the meantime, here's a demo of how we can use Scalacheck to create integration tests that confirm that serving a function through Serial gives the same results as the original function.

I used your #19 because it makes things a bit cleaner, but I'm happy to rebase if you've changed your mind on that.
