### PR TITLE
Move exceptional codecs from Serial to ScodecSerial

### DIFF
--- a/core/src/main/scala/io/github/finagle/Serial.scala
+++ b/core/src/main/scala/io/github/finagle/Serial.scala
@@ -6,7 +6,6 @@ import com.twitter.finagle.client.StackClient
 import com.twitter.finagle.server.StackServer
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Try}
-import io.github.finagle.serial._
 import java.net.SocketAddress
 import scala.language.higherKinds
 
@@ -19,29 +18,6 @@ trait Serial {
    * Represents a codec for a given type.
    */
   type C[_]
-
-  /**
-   * A codec for encoding errors.
-   *
-   * Because encoding errors are sent over the wire, an implementation needs to
-   * specify how to encode them.
-   */
-  def codecErrorCodec: C[CodecError]
-
-  /**
-   * A codec for "fall-back" errors.
-   *
-   * This will be used if [[io.github.finagle.Serial#applicationErrorCodec]]
-   * does not successfully encode an application error.
-   */
-  def unhandledApplicationErrorCodec: C[ApplicationError]
-
-  /**
-   * A codec for application errors.
-   *
-   * Implementations may decide which errors they wish to serialize.
-   */
-  def applicationErrorCodec: C[Throwable]
 
   /**
    * Encode a request.

--- a/core/src/main/scala/io/github/finagle/serial/errors.scala
+++ b/core/src/main/scala/io/github/finagle/serial/errors.scala
@@ -1,7 +1,5 @@
 package io.github.finagle.serial
 
-import com.twitter.util.Try
-
 /**
  * Represents an error that occurs during encoding or decoding.
  */

--- a/scodec/src/main/scala/io/github/finagle/serial/scodec/ScodecSerial.scala
+++ b/scodec/src/main/scala/io/github/finagle/serial/scodec/ScodecSerial.scala
@@ -17,13 +17,28 @@ trait ScodecSerial extends Serial {
    */
   private[this] lazy val stringWithLength: Codec[String] = variableSizeBits(uint24, utf8)
 
+  /**
+   * A codec for encoding errors.
+   *
+   * Because encoding errors are sent over the wire, an implementation needs to
+   * specify how to encode them.
+   */
   lazy val codecErrorCodec: Codec[CodecError] = stringWithLength.hlist.as[CodecError]
 
+  /**
+   * A codec for "fall-back" errors.
+   *
+   * This will be used if [[io.github.finagle.Serial#applicationErrorCodec]]
+   * does not successfully encode an application error.
+   */
   lazy val unhandledApplicationErrorCodec: Codec[ApplicationError] =
     stringWithLength.hlist.as[ApplicationError]
 
   /**
-   * By default we only encode a few exceptions from the standard library.
+   * A codec for application errors.
+   *
+   * Implementations may decide which errors they wish to serialize. By default
+   * we only encode a few exceptions from the standard library.
    */
   lazy val applicationErrorCodec: Codec[Throwable] = ApplicationErrorCodec.basic.underlying
 


### PR DESCRIPTION
As we agreed in chat, moving exceptional codecs from `Serial` to `ScodecSerial`.
