### PR TITLE
A nicer representation of reponses for Scodec

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,12 @@ Check the `test` project documentation for more information about these tools.
 
 We also provide a very preliminary `benchmark` project that uses [JMH][9] to
 compare the performance of the Scodec backend to a similar Finagle Thrift
-service. In our initial testing, the Scodec backend manages about 40% of the
+service. In our initial testing, the Scodec backend manages about 46% of the
 throughput of the Thrift implementation:
 
 ```
-i.g.f.s.RoundTripThriftSmallBenchmark.test    thrpt       20  21221.289 ± 483.478  ops/s
-i.g.f.s.ScodecSmallRTBenchmark.test           thrpt       20   8607.848 ± 244.856  ops/s
+i.g.f.s.RoundTripThriftSmallBenchmark.test    thrpt       20  22422.923 ± 1098.352  ops/s
+i.g.f.s.ScodecSmallRTBenchmark.test           thrpt       20  10335.675 ± 190.058  ops/s
 ```
 
 These benchmarks (even more than most benchmarks) should be taken with a grain

--- a/scodec/src/main/scala/io/github/finagle/serial/scodec/RepMessage.scala
+++ b/scodec/src/main/scala/io/github/finagle/serial/scodec/RepMessage.scala
@@ -1,0 +1,41 @@
+package io.github.finagle.serial.scodec
+
+import _root_.scodec.Codec
+import _root_.scodec.codecs._
+import com.twitter.util.{Return, Throw, Try}
+import io.github.finagle.serial.{CodecError, ApplicationError}
+
+private[scodec] sealed trait RepMessage[A] {
+  def toTry: Try[A]
+}
+
+private[scodec] case class ContentRepMessage[A](a: A) extends RepMessage[A] {
+  def toTry = Return(a)
+}
+
+private[scodec] case class CodecErrorRepMessage[A](err: CodecError) extends RepMessage[A] {
+  def toTry = Throw(err)
+}
+
+private[scodec] case class ApplicationErrorRepMessage[A](err: Throwable) extends RepMessage[A] {
+  def toTry = Throw(err)
+}
+
+private[scodec] case class UnhandledApplicationErrorRepMessage[A](err: ApplicationError)
+  extends RepMessage[A] {
+    def toTry = Throw(err)
+  }
+
+private[scodec] object RepMessage {
+  def codec[A](
+    aCodec: Codec[A],
+    codecErrorCodec: Codec[CodecError],
+    applicationErrorCodec: Codec[Throwable],
+    unhandledApplicationErrorCodec: Codec[ApplicationError]
+  ): Codec[RepMessage[A]] = (
+    aCodec.as[ContentRepMessage[A]] :+:
+    codecErrorCodec.as[CodecErrorRepMessage[A]] :+:
+    applicationErrorCodec.as[ApplicationErrorRepMessage[A]] :+:
+    unhandledApplicationErrorCodec.as[UnhandledApplicationErrorRepMessage[A]]
+  ).discriminatedByIndex(uint4).as[RepMessage[A]]
+}


### PR DESCRIPTION
This gives us a slight performance improvement for Scodec by flattening the representation of responses into an ADT instead of using nested eithers. More importantly it's cleaner code.
