### PR TITLE
Version updates and minor syntactic SBT cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 
 scala:
-  - 2.10.4
-  - 2.11.5
+  - 2.10.5
+  - 2.11.6
 
 jdk:
   - openjdk7
@@ -10,7 +10,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION coverage test it:test
+  - travis_retry sbt ++$TRAVIS_SCALA_VERSION coverage test it:test
 
 after_success:
   - sbt coveralls

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 lazy val commonSettings = Seq(
   organization := "io.github.finagle",
   version := "0.0.1",
-  scalaVersion := "2.11.5",
-  crossScalaVersions := Seq("2.10.4", "2.11.5"),
+  scalaVersion := "2.11.6",
+  crossScalaVersions := Seq("2.10.5", "2.11.6"),
   libraryDependencies ++= Seq(
     "com.twitter" %% "finagle-mux" % "6.24.0"
   ) ++ testDependencies.map(_ % "test"),
@@ -15,17 +15,14 @@ lazy val commonSettings = Seq(
 )
 
 lazy val testDependencies = Seq(
-  "org.scalatest" %% "scalatest" % "2.2.3",
-  "org.scalacheck" %% "scalacheck" % "1.12.1"
+  "org.scalatest" %% "scalatest" % "2.2.4",
+  "org.scalacheck" %% "scalacheck" % "1.12.2"
 )
 
 lazy val root = project.in(file("."))
   .settings(moduleName := "finagle-serial")
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
-  .settings(unidocSettings: _*)
-  .settings(site.settings: _*)
-  .settings(ghpages.settings: _*)
+  .settings(commonSettings ++ publishSettings)
+  .settings(unidocSettings ++ site.settings ++ ghpages.settings)
   .settings(
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject -- inProjects(benchmark),
     site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "docs"),
@@ -35,22 +32,19 @@ lazy val root = project.in(file("."))
 
 lazy val core = project
   .settings(moduleName := "finagle-serial-core")
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
+  .settings(commonSettings ++ publishSettings)
   .disablePlugins(CoverallsPlugin)
 
 lazy val test = project
   .settings(moduleName := "finagle-serial-test")
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
+  .settings(commonSettings ++ publishSettings)
   .settings(libraryDependencies ++= testDependencies)
   .settings(coverageExcludedPackages := "io\\.github\\.finagle\\.serial\\.test\\..*")
   .dependsOn(core)
   .disablePlugins(CoverallsPlugin)
 
 lazy val scodecSettings = Seq(
-  resolvers += Resolver.sonatypeRepo("snapshots"),
-  libraryDependencies += "org.scodec" %% "scodec-core" % "1.8.0-SNAPSHOT",
+  libraryDependencies += "org.scodec" %% "scodec-core" % "1.7.1",
   // This is necessary for 2.10 because of Scodec's Shapeless dependency.
   libraryDependencies ++= (
     if (scalaBinaryVersion.value.startsWith("2.10")) Seq(
@@ -62,19 +56,13 @@ lazy val scodecSettings = Seq(
 lazy val scodec = project
   .settings(moduleName := "finagle-serial-scodec")
   .configs(IntegrationTest)
-  .settings(Defaults.itSettings: _*)
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
-  .settings(scodecSettings: _*)
+  .settings(commonSettings ++ publishSettings ++ scodecSettings ++ Defaults.itSettings)
   .dependsOn(core, test % "it")
   .disablePlugins(CoverallsPlugin)
 
 lazy val benchmark = project
   .settings(moduleName := "finagle-serial-benchmark")
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
-  .settings(scodecSettings: _*)
-  .settings(jmhSettings: _*)
+  .settings(commonSettings ++ publishSettings ++ scodecSettings ++ jmhSettings)
   .settings(
     libraryDependencies ++= Seq(
       "com.twitter" %% "finagle-thriftmux" % "6.24.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
   Classpaths.sbtPluginReleases
 )
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")


### PR DESCRIPTION
The only substantive thing here is that I switched from the 1.8.0 snapshot for scodec to the 1.7.1 release, which has everything we need.
