### PR TITLE
Version updates and some miscellaneous clean-up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.10.5
-  - 2.11.6
+  - 2.11.7
 
 jdk:
   - openjdk7

--- a/benchmark/src/main/scala/io/github/finagle/serial/benchmark/RoundTripBenchmark.scala
+++ b/benchmark/src/main/scala/io/github/finagle/serial/benchmark/RoundTripBenchmark.scala
@@ -1,4 +1,4 @@
-package i.g.f.s
+package io.github.finagle.serial.benchmark
 
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit

--- a/benchmark/src/main/scala/io/github/finagle/serial/benchmark/RoundTripThriftSmallBenchmark.scala
+++ b/benchmark/src/main/scala/io/github/finagle/serial/benchmark/RoundTripThriftSmallBenchmark.scala
@@ -1,4 +1,4 @@
-package i.g.f.s
+package io.github.finagle.serial.benchmark
 
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
@@ -8,7 +8,7 @@ import com.twitter.util.{Closable, Await, Future}
 import org.openjdk.jmh.annotations._
 
 /**
- * run -i 10 -wi 7 -f 2 -t 1 i.g.f.s.RoundTripThriftSmallBenchmark
+ * run -i 10 -wi 7 -f 2 -t 1 io.github.finagle.serial.benchmark.RoundTripThriftSmallBenchmark
  */
 @State(Scope.Thread)
 class RoundTripThriftSmallBenchmark {

--- a/benchmark/src/main/scala/io/github/finagle/serial/benchmark/ScodecSmallRTBenchmark.scala
+++ b/benchmark/src/main/scala/io/github/finagle/serial/benchmark/ScodecSmallRTBenchmark.scala
@@ -1,9 +1,9 @@
-package i.g.f.s
+package io.github.finagle.serial.benchmark
 
 import io.github.finagle.serial.scodec.ScodecSerial
 
 /**
- * run -i 10 -wi 7 -f 2 -t 1 i.g.f.s.ScodecSmallRTBenchmark
+ * run -i 10 -wi 7 -f 2 -t 1 io.github.finagle.serial.benchmark.ScodecSmallRTBenchmark
  */
 class ScodecSmallRTBenchmark extends RoundTripBenchmark(Workload.small) {
 

--- a/benchmark/src/main/scala/io/github/finagle/serial/benchmark/Workload.scala
+++ b/benchmark/src/main/scala/io/github/finagle/serial/benchmark/Workload.scala
@@ -1,4 +1,4 @@
-package i.g.f.s
+package io.github.finagle.serial.benchmark
 
 import java.util.UUID
 

--- a/benchmark/src/main/thrift/small.thrift
+++ b/benchmark/src/main/thrift/small.thrift
@@ -1,12 +1,8 @@
-#@namespace scala i.g.f.s.thriftscala
+#@namespace scala io.github.finagle.serial.benchmark.thriftscala
 
 struct Small {
   1: list<bool> booleans;
-  2: string string;
-}
-
-exception NameRecognizerException {
-  1: string description;
+  2: string body;
 }
 
 service EchoService {

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val commonSettings = Seq(
       case _ => Seq.empty
     }
   ),
+  scalacOptions in (Compile, console) := compilerOptions,
   resolvers += "Twitter's Repository" at "https://maven.twttr.com/",
   parallelExecution in Test := false
 )
@@ -48,7 +49,18 @@ lazy val root = project.in(file("."))
     site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "docs"),
     git.remoteRepo := "git@github.com:finagle/finagle-serial.git"
   )
+  .settings(
+    initialCommands in console :=
+      """
+        |import com.twitter.finagle.Service
+        |import com.twitter.util.Future
+        |import io.github.finagle.serial.scodec.ScodecSerial
+        |import scodec.Codec
+        |import scodec.codecs._
+      """.stripMargin
+  )
   .aggregate(core, test, scodec, benchmark)
+  .dependsOn(core, scodec)
 
 lazy val core = project
   .settings(moduleName := "finagle-serial-core")

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,42 @@
 import UnidocKeys._
 import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
+lazy val compilerOptions = Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-feature",
+  "-language:existentials",
+  "-language:higherKinds",
+  "-language:implicitConversions",
+  "-unchecked",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-numeric-widen",
+  "-Xfuture",
+  "-Xlint"
+)
+
 lazy val commonSettings = Seq(
   organization := "io.github.finagle",
   version := "0.0.1",
-  scalaVersion := "2.11.6",
-  crossScalaVersions := Seq("2.10.5", "2.11.6"),
+  scalaVersion := "2.11.7",
+  crossScalaVersions := Seq("2.10.5", "2.11.7"),
   libraryDependencies ++= Seq(
-    "com.twitter" %% "finagle-mux" % "6.25.0"
+    "com.twitter" %% "finagle-mux" % "6.26.0"
   ) ++ testDependencies.map(_ % "test"),
-  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
-  resolvers += "Twitter's Repository" at "http://maven.twttr.com/",
+  scalacOptions ++= compilerOptions ++ (
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 11)) => Seq("-Ywarn-unused-import")
+      case _ => Seq.empty
+    }
+  ),
+  resolvers += "Twitter's Repository" at "https://maven.twttr.com/",
   parallelExecution in Test := false
 )
 
 lazy val testDependencies = Seq(
-  "org.scalatest" %% "scalatest" % "2.2.4",
-  "org.scalacheck" %% "scalacheck" % "1.12.2"
+  "org.scalacheck" %% "scalacheck" % "1.12.4",
+  "org.scalatest" %% "scalatest" % "2.2.5"
 )
 
 lazy val root = project.in(file("."))
@@ -44,7 +64,7 @@ lazy val test = project
   .disablePlugins(CoverallsPlugin)
 
 lazy val scodecSettings = Seq(
-  libraryDependencies += "org.scodec" %% "scodec-core" % "1.7.1",
+  libraryDependencies += "org.scodec" %% "scodec-core" % "1.8.1",
   // This is necessary for 2.10 because of Scodec's Shapeless dependency.
   libraryDependencies ++= (
     if (scalaBinaryVersion.value.startsWith("2.10")) Seq(
@@ -65,7 +85,7 @@ lazy val benchmark = project
   .settings(commonSettings ++ publishSettings ++ scodecSettings ++ jmhSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.twitter" %% "finagle-thriftmux" % "6.25.0",
+      "com.twitter" %% "finagle-thriftmux" % "6.26.0",
       "com.twitter" %% "scrooge-core" % "3.17.0"
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,12 +5,12 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.1.8")
 
 // Used only in the benchmark project
-addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.14.1")
+addSbtPlugin("com.twitter" %% "scrooge-sbt-plugin" % "3.16.3")

--- a/scodec/src/main/scala/io/github/finagle/serial/scodec/ApplicationErrorCodec.scala
+++ b/scodec/src/main/scala/io/github/finagle/serial/scodec/ApplicationErrorCodec.scala
@@ -53,4 +53,3 @@ object ApplicationErrorCodec {
       case e: NoSuchElementException => e.getMessage
     }
 }
-

--- a/scodec/src/main/scala/io/github/finagle/serial/scodec/ScodecSerial.scala
+++ b/scodec/src/main/scala/io/github/finagle/serial/scodec/ScodecSerial.scala
@@ -111,4 +111,3 @@ trait ScodecSerial extends Serial {
 }
 
 object ScodecSerial extends ScodecSerial
-

--- a/scodec/src/test/scala/io/github/finagle/serial/scodec/ScodecCodecSpec.scala
+++ b/scodec/src/test/scala/io/github/finagle/serial/scodec/ScodecCodecSpec.scala
@@ -2,11 +2,7 @@ package io.github.finagle.serial.scodec
 
 import _root_.scodec._
 import _root_.scodec.bits.BitVector
-import _root_.scodec.codecs._
-import com.twitter.finagle.Service
-import com.twitter.util.{Await, Future, Return}
 import io.github.finagle.serial.{CodecError, ApplicationError}
-import java.net.InetSocketAddress
 import org.scalatest.{Matchers, FlatSpec}
 
 class ScodecCodecSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
Not sure why but in the benchmark Scodec is consistently performing better after these updates (51% of the throughput from Thrift as opposed to 46%).
